### PR TITLE
fix: increase storedKey hash security by using a new hash function

### DIFF
--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -35,9 +35,19 @@ pub fn compute_mac(derived_key: &[u8], encrypted_text: &[u8]) -> Vec<u8> {
     output.to_vec()
 }
 
-pub fn dsha256(input: &[u8]) -> Vec<u8> {
-    use sha2::{ Digest, Sha256 };
-    Sha256::digest(&Sha256::digest(&input)).to_vec()
+pub fn binary_sha256(input: &[u8]) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+    let input_len = input.len();
+    if input_len > 1 {
+        let (first_half, second_half) = input.split_at(input_len / 2);
+        let first_hash = &Sha256::digest(&first_half);
+        let second_hash = &Sha256::digest(&second_half);
+        Sha256::digest(&[&first_hash[..], &second_hash[..]].concat()).to_vec()
+    } else {
+        let first_hash = &Sha256::digest(&input);
+        let second_hash = &Sha256::digest(&input);
+        Sha256::digest(&[&first_hash[..], &second_hash[..]].concat()).to_vec()
+    }
 }
 
 #[cfg(test)]

--- a/wallet/src/stored_key.rs
+++ b/wallet/src/stored_key.rs
@@ -49,12 +49,12 @@ impl StoredKey {
         let uuid = Uuid::new_v4();
         let payload = EncryptionParams::new(password.as_bytes(), &data)?;
         let hash = match r#type {
-            StoredKeyType::PrivateKey => hash::dsha256(&data),
+            StoredKeyType::PrivateKey => hash::binary_sha256(&data),
             StoredKeyType::Mnemonic => {
                 let mnemonic_str = std::str::from_utf8(&data)
                     .map_err(|_| Error::CryptoError(CryptoError::PasswordIncorrect))?;
                 let mnemonic = Mnemonic::new(&mnemonic_str, &password)?;
-                hash::dsha256(&mnemonic.seed)
+                hash::binary_sha256(&mnemonic.seed)
             }
         };
         Ok(StoredKey {


### PR DESCRIPTION
Using a new hash method to improve the `StoredKey`'s hash string security:
1. Split the input into 2 sub-lists using `split_at` method. If the input's length is 1, simply use 2 inputs as the 2 sub-lists.
2. Hash the 2 sub-lists using Sha256 digest
3. Concatenate the 2 Sha256 digested lists.
4. Hash the output of step 3 using Sha256 as the final output